### PR TITLE
Add Terraform-based azd template for Shiny app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+infra/.terraform/
+infra/.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # azd-shiny
-Azure Developer CLI Template for R Shiny Apps
+
+This repository contains an **Azure Developer CLI** (azd) template for deploying a simple [R Shiny](https://shiny.posit.co/) application to Azure using **Terraform**.
+
+## Quickstart
+
+Ensure you have the [Azure Developer CLI](https://aka.ms/azd-install) and [Terraform](https://aka.ms/azure-dev/terraform-install) installed. Then run:
+
+```bash
+azd init --template <repository-url>
+azd up
+```
+
+After provisioning, `azd` will output the URL of the running Shiny app.
+
+## Template Structure
+
+- `src/` – sample Shiny app and Dockerfile
+- `infra/` – Terraform infrastructure for Azure resources
+- `azure.yaml` – configuration for azd
+
+Replace the sample app in `src/app.R` with your own Shiny code.

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,0 +1,8 @@
+name: r-shiny-terraform
+infra:
+  provider: terraform
+services:
+  shiny:
+    project: ./src
+    language: docker
+    host: appservice

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,44 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.environment_name}-rg"
+  location = var.location
+}
+
+resource "azurerm_container_registry" "acr" {
+  name                = "${var.environment_name}acr"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+  sku                 = "Basic"
+  admin_enabled       = true
+}
+
+resource "azurerm_app_service_plan" "plan" {
+  name                = "${var.environment_name}-plan"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "B1"
+    size = "B1"
+  }
+}
+
+resource "azurerm_linux_web_app" "app" {
+  name                = "${var.environment_name}-shiny"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+  service_plan_id     = azurerm_app_service_plan.plan.id
+
+  site_config {
+    linux_fx_version = "DOCKER|${azurerm_container_registry.acr.login_server}/${var.image_name}:latest"
+  }
+
+  app_settings = {
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE = "false"
+    WEBSITES_PORT                       = "3838"
+    DOCKER_REGISTRY_SERVER_URL          = azurerm_container_registry.acr.login_server
+    DOCKER_REGISTRY_SERVER_USERNAME     = azurerm_container_registry.acr.admin_username
+    DOCKER_REGISTRY_SERVER_PASSWORD     = azurerm_container_registry.acr.admin_password
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,3 @@
+output "web_app_url" {
+  value = "https://${azurerm_linux_web_app.app.default_hostname}"
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,15 @@
+variable "location" {
+  description = "Azure region for deployment"
+  type        = string
+}
+
+variable "environment_name" {
+  description = "Name of the azd environment"
+  type        = string
+}
+
+variable "image_name" {
+  description = "Container image name"
+  type        = string
+  default     = "shinyapp"
+}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,7 @@
+FROM rocker/shiny:latest
+
+COPY app.R /srv/shiny-server/
+
+EXPOSE 3838
+
+CMD ["/usr/bin/shiny-server"]

--- a/src/app.R
+++ b/src/app.R
@@ -1,0 +1,22 @@
+library(shiny)
+
+ui <- fluidPage(
+  titlePanel("Hello Shiny!"),
+  sidebarLayout(
+    sidebarPanel(
+      sliderInput("obs", "Number of observations:",
+                  min = 1, max = 100, value = 50)
+    ),
+    mainPanel(
+      plotOutput("distPlot")
+    )
+  )
+)
+
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+}
+
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
## Summary
- initialize azd template using Terraform
- add sample Shiny app and Dockerfile
- provide basic Terraform infrastructure and configuration
- update .gitignore for terraform files

## Testing
- `terraform init -input=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_b_68549731ee0883339ef334c34fe948aa